### PR TITLE
Preserve key type in `tuff.array.groupBy*` where possible

### DIFF
--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -6,23 +6,23 @@ import { KeyOfType } from "./forms"
  * @param key the key by which to group
  * @returns on objects mapping key to grouped elements
  */
-export function groupBy<T extends object, K extends KeyOfType<T,string> & string>(array: T[], key: K): Record<string, T[]> {
+export function groupBy<T extends object, K extends keyof T, TK extends T[K] & (string | number | symbol)>(array: T[], key: K): Record<TK, T[]> {
     return array.reduce((previous, currentItem) => {
         // I don't know why typescript can't figure this out
-        const group = currentItem[key] as unknown as string|undefined
+        const group = currentItem[key] as TK
         if (group) {
             if (!previous[group]) previous[group] = []
             previous[group].push(currentItem)
         }
         return previous
-    }, {} as Record<string, T[]>)
+    }, {} as Record<TK, T[]>)
 }
 
 
 /**
  * Type for a function that returns a groupBy key from a type.
  */
-type KeyFun<T> = (item: T) => string | undefined
+type KeyFun<T, K> = (item: T) => K | undefined
 
 
 /**
@@ -31,7 +31,7 @@ type KeyFun<T> = (item: T) => string | undefined
  * @param getKey a function returning the key by which to group
  * @returns on objects mapping key to grouped elements
  */ 
-export function groupByFunction<T extends object>(list: T[], getKey: KeyFun<T>): Record<string, T[]> {
+export function groupByFunction<T extends object, K extends string | number | symbol>(list: T[], getKey: KeyFun<T, K>): Record<K, T[]> {
     return list.reduce((previous, currentItem) => {
         const group = getKey(currentItem)
         if (group) {
@@ -39,13 +39,13 @@ export function groupByFunction<T extends object>(list: T[], getKey: KeyFun<T>):
             previous[group].push(currentItem)
         }
         return previous
-    }, {} as Record<string, T[]>)
+    }, {} as Record<K, T[]>)
 }
 
 /**
  * Iterates over the results of groupByFunction
  */
-export function eachGroupByFunction<T extends object, K extends keyof T>(list: T[], getKey: KeyFun<T>, fun: (key: K, values: T[]) => any) {
+export function eachGroupByFunction<T extends object, K extends string | number | symbol>(list: T[], getKey: KeyFun<T, K>, fun: (key: K, values: T[]) => any) {
     for (let [k, v] of Object.entries(groupByFunction(list, getKey))) {
         fun(k as K, v as T[])
     }

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -8,7 +8,6 @@ import { KeyOfType } from "./forms"
  */
 export function groupBy<T extends object, K extends keyof T, TK extends T[K] & (string | number | symbol)>(array: T[], key: K): Record<TK, T[]> {
     return array.reduce((previous, currentItem) => {
-        // I don't know why typescript can't figure this out
         const group = currentItem[key] as TK
         if (group) {
             if (!previous[group]) previous[group] = []
@@ -31,7 +30,7 @@ type KeyFun<T, K> = (item: T) => K | undefined
  * @param getKey a function returning the key by which to group
  * @returns on objects mapping key to grouped elements
  */ 
-export function groupByFunction<T extends object, K extends string | number | symbol>(list: T[], getKey: KeyFun<T, K>): Record<K, T[]> {
+export function groupByFunction<T extends object, TK extends string | number | symbol>(list: T[], getKey: KeyFun<T, TK>): Record<TK, T[]> {
     return list.reduce((previous, currentItem) => {
         const group = getKey(currentItem)
         if (group) {
@@ -39,15 +38,15 @@ export function groupByFunction<T extends object, K extends string | number | sy
             previous[group].push(currentItem)
         }
         return previous
-    }, {} as Record<K, T[]>)
+    }, {} as Record<TK, T[]>)
 }
 
 /**
  * Iterates over the results of groupByFunction
  */
-export function eachGroupByFunction<T extends object, K extends string | number | symbol>(list: T[], getKey: KeyFun<T, K>, fun: (key: K, values: T[]) => any) {
+export function eachGroupByFunction<T extends object, TK extends string | number | symbol>(list: T[], getKey: KeyFun<T, TK>, fun: (key: TK, values: T[]) => any) {
     for (let [k, v] of Object.entries(groupByFunction(list, getKey))) {
-        fun(k as K, v as T[])
+        fun(k as TK, v as T[])
     }
 }
 

--- a/src/test/arrays.test.ts
+++ b/src/test/arrays.test.ts
@@ -31,22 +31,46 @@ test("unique", () => {
 })
 
 
-test("groupBy and groupByFunction", () => {
+test("groupBy", () => {
+    type ID = "one" | "two"
     const array = [
-        {id: "one", foo: "bar"},
-        {id: "one", foo: "hello"},
-        {id: "two", foo: "baz"},
-        {id: "two", foo: "world"},
+        {id: "one" as ID, foo: "bar"},
+        {id: "one" as ID, foo: "hello"},
+        {id: "two" as ID, foo: "baz"},
+        {id: "two" as ID, foo: "world"},
     ]
     const grouped = arrays.groupBy(array, "id")
     expect(Object.keys(grouped).length).eq(2)
     expect(grouped["one"]).toMatchObject([{id: "one", foo: "bar"}, {id: "one", foo: "hello"}])
     expect(grouped["two"]).toMatchObject([{id: "two", foo: "baz"}, {id: "two", foo: "world"}])
+})
 
-    const funGrouped = arrays.groupByFunction(array, a => a['id'])
-    expect(Object.keys(funGrouped).length).eq(2)
-    expect(funGrouped["one"]).toMatchObject([{id: "one", foo: "bar"}, {id: "one", foo: "hello"}])
-    expect(funGrouped["two"]).toMatchObject([{id: "two", foo: "baz"}, {id: "two", foo: "world"}])
+test("groupByFunction", () => {
+    type ID = "one" | "two"
+    const array = [
+        {id: "one" as ID, foo: "bar"},
+        {id: "one" as ID, foo: "hello"},
+        {id: "two" as ID, foo: "baz"},
+        {id: "two" as ID, foo: "world"},
+    ]
+    const grouped = arrays.groupByFunction(array, a => a['id'])
+    expect(Object.keys(grouped).length).eq(2)
+    expect(grouped["one"]).toMatchObject([{id: "one", foo: "bar"}, {id: "one", foo: "hello"}])
+    expect(grouped["two"]).toMatchObject([{id: "two", foo: "baz"}, {id: "two", foo: "world"}])
+})
+
+test("groupByFunction with non-object-key group key", () => {
+    type ID = "one" | "two"
+    const array = [
+        {id: "one" as ID, foo: "bar"},
+        {id: "one" as ID, foo: "hello"},
+        {id: "two" as ID, foo: "baz"},
+        {id: "two" as ID, foo: "world"},
+    ]
+    const grouped = arrays.groupByFunction(array, a => a['id'] + "_key")
+    expect(Object.keys(grouped).length).eq(2)
+    expect(grouped["one_key"]).toMatchObject([{id: "one", foo: "bar"}, {id: "one", foo: "hello"}])
+    expect(grouped["two_key"]).toMatchObject([{id: "two", foo: "baz"}, {id: "two", foo: "world"}])
 })
 
 test("indexBy", () => {


### PR DESCRIPTION
If we're grouping by a value that has a more restrictive type than string (e.g. "one" | "two" | "three"), the keys of the resulting grouped record will keep that restricted type

A potential example from hub:

```ts
const postsByLane : Record<NonNullable<Post['lane']>, Array<Post>> = tuff.arrays.groupByFunction(allPosts, p => p.lane ?? 'asap')
```