### PR TITLE
Store files with key 'files' rather than input name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tuff-core",
-  "version": "0.21.08",
+  "version": "0.22.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tuff-core",
-      "version": "0.21.08",
+      "version": "0.22.2",
       "license": "MIT",
       "dependencies": {
         "@types/path-to-regexp": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "files": [
     "*"
   ],
-  "version": "0.22.1",
+  "version": "0.22.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Terrier-Tech/tuff"

--- a/src/demo/contacts.ts
+++ b/src/demo/contacts.ts
@@ -110,7 +110,7 @@ class ContactFormPart extends forms.FormPart<ContactState> {
 
             const fileInput = m.event.target as HTMLInputElement
             const data = await this.serializeFileInput(fileInput)
-            const photos = data.getAll(fileInput.name) as Array<File>
+            const photos = data.getAll('files') as Array<File>
 
             if (data && photos.length) {
                 for (const photo of photos) {

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -157,8 +157,11 @@ export abstract class FormPart<DataType extends FormPartData> extends Part<DataT
     /**
      * Serializes the file input into a FormData object.
      * This is async so that subclasses can override it and do async things.
+     * @param   input       file input
+     * @param   key         key to associate files with in FormData
+     * @returns FormData    contains files
      */
-    async serializeFileInput(input: HTMLInputElement): Promise<FormData> {
+    async serializeFileInput(input: HTMLInputElement, key?: string): Promise<FormData> {
         const root = this.element
         const data: FormData = new FormData()
 
@@ -167,8 +170,9 @@ export abstract class FormPart<DataType extends FormPartData> extends Part<DataT
         }
 
         const fileList: FileList = input.files
+        key = key ?? 'files'
         for (let i = 0; i < fileList.length; i++) {
-            data.append(input.name, fileList[i])
+            data.append(key, fileList[i])
         }
         return data
     }


### PR DESCRIPTION
I don't think there's any need to be quite that specific/use the input name as the key in the `FormData` because we'll always have a separate `FormData` object for each file input. Makes it easier to deal with things on the server side:

![CleanShot 2023-02-02 at 11 26 19@2x](https://user-images.githubusercontent.com/43075531/216397660-5c6c28e8-f366-4f06-adcb-c5fd3c01bb14.png)
(From hub `application_controller.rb`)