### PR TITLE
Add `Part#renderAsElement`

### DIFF
--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -4,6 +4,7 @@ import * as styles from './styles.css'
 import * as counter from './counter'
 import * as contacts from './contacts'
 import * as shapes from './shapes'
+import * as table from './table'
 import * as nav from './nav'
 import * as demo from './demo'
 import Html from '../html'
@@ -49,6 +50,7 @@ class App extends Part<{}> {
         this.parts['Counter'] = this.makeStatelessPart(counter.CounterApp)
         this.parts['Contacts'] = this.makeStatelessPart(contacts.ContactsApp)
         this.parts['Shapes'] = this.makeStatelessPart(shapes.ShapesApp)
+        this.parts['Table'] = this.makePart(table.Table, {})
         this.parts['Nav'] = this.makeStatelessPart(nav.NavApp)
 
         this.output.write("Initialized!")

--- a/src/demo/styles.css.ts
+++ b/src/demo/styles.css.ts
@@ -265,3 +265,26 @@ export const navChild = style({
     padding: '2em',
     textAlign: 'center'
 })
+
+
+// Tables
+
+export const dataTable = style({
+    borderCollapse: "collapse",
+    width: "100%",
+    borderRadius: sizes.borderRadius,
+    overflow: "hidden",
+})
+
+globalStyle(`${dataTable} thead tr`, {
+    backgroundColor: colors.button,
+    color: '#fff',
+})
+
+globalStyle(`${dataTable} tbody tr:nth-child(even)`, {
+    backgroundColor: "rgba(0,0,0,0.1)",
+})
+
+globalStyle(`${dataTable} td, ${dataTable} th`, {
+    padding: "5px",
+})

--- a/src/demo/table.ts
+++ b/src/demo/table.ts
@@ -1,0 +1,47 @@
+import { HtmlParentTag } from "../html"
+import { Part, PartTag } from "../parts"
+import * as styles from './styles.css'
+
+export type Person = { id: string, name: string, birthday?: string }
+
+export class Table extends Part<{ people?: Person[] }> {
+    rows!: TableRow[]
+
+    async init() {
+        this.state.people ??= [
+            { id: '1', name: "Alice", birthday: "Feb 29" },
+            { id: '2', name: "Bob" },
+            { id: '3', name: "Charlie", birthday: "Jan 1" },
+            { id: '4', name: "Denise", birthday: "Dec 31" },
+        ]
+        this.rows = this.state.people.map(c => this.makePart(TableRow, c))
+    }
+
+    render(parent: PartTag) {
+        parent.table(styles.dataTable, table => {
+            table.thead().tr(tr => {
+                tr.th().text("ID")
+                tr.th().text("Name")
+                tr.th().text("Birthday")
+            })
+            for (const row of this.rows) {
+                table.part(row)
+            }
+        })
+    }
+
+}
+
+class TableRow extends Part<Person> {
+
+    get renderAsElement(): keyof HTMLElementTagNameMap & keyof HtmlParentTag {
+        return "tr"
+    }
+
+    render(parent: PartTag) {
+        parent.td().text(this.state.id)
+        parent.td().text(this.state.name)
+        parent.td().text(this.state.birthday ?? "Birthdayless")
+    }
+
+}

--- a/src/parts.ts
+++ b/src/parts.ts
@@ -9,8 +9,9 @@ import {
 } from './messages'
 import {Logger} from './logging'
 import * as keyboard from './keyboard'
+import { TagArgs } from "./tags"
 import * as urls from './urls'
-import Html, {DivTag, HtmlBaseAttrs, HtmlParentTag, HtmlTagBase} from './html'
+import Html, { DivTag, HtmlBaseAttrs, HtmlParentTag, HtmlTagBase } from './html'
 import Nav from './nav'
 import {PartPlugin, PluginConstructor, StatelessPlugin} from "./plugins"
 import Strings from "./strings"
@@ -735,11 +736,17 @@ export abstract class Part<StateType> {
     
     /// Rendering
 
+    get renderAsElement(): keyof HTMLElementTagNameMap & keyof HtmlParentTag {
+        return 'div'
+    }
+
     renderInTag(container: HtmlParentTag, ...classes: string[]) {
         const partClass = this.name;
         const c = [...classes]
         c.push(`tuff-part-${partClass}`)
-        container.div({ id: this.id, classes: c, data: { tuffPart: partClass }}, parent => {
+        const tagName = this.renderAsElement
+        const tagFunc = container[tagName] as (...args: TagArgs<HtmlParentTag,HtmlBaseAttrs>[]) => HtmlParentTag
+        tagFunc.bind(container)({ id: this.id, classes: c, data: { tuffPart: partClass }}, parent => {
             parent.class(...this.parentClasses)
             if (this.isInitialized) {
                 this._renderState = "clean"


### PR DESCRIPTION
Allow parts to be rendered as whatever element type they want. Default is still `div`. Motivation is wanting to render a part as a row in a table. Since you can't have a div surrounding a `tr` element, everything breaks. But by rendering the part _as_ a `tr`, the issue is resolved (see table demo)