### PR TITLE
Display route parsing errors

### DIFF
--- a/src/demo/errors.ts
+++ b/src/demo/errors.ts
@@ -1,4 +1,5 @@
 import { Part, PartTag } from "../parts"
+import Time from "../time"
 import * as styles from './styles.css'
 
 /**
@@ -7,6 +8,7 @@ import * as styles from './styles.css'
 class InitErrorPart extends Part<{}> {
 
     async init() {
+        await Time.wait(500)
         throw "This error was thrown during init(). This part's render() method will never get called."
     }
 

--- a/src/demo/nav.ts
+++ b/src/demo/nav.ts
@@ -62,6 +62,7 @@ const routes = {
     foo: partRoute(IdChildPart, "/foo/:id", {
         id: stringParser
     }),
+    requiredFoo: partRoute(IdChildPart, "/required_foo&:id", { id: stringParser }),
     hola: redirectRoute('/hola', '/hello'),
     withOptional: partRoute(OptionalParamPart, "/alpha/:bravo?/charlie&:delta?", { bravo: optionalIntParser, delta: optionalStringParser })
 }

--- a/src/parts.ts
+++ b/src/parts.ts
@@ -287,6 +287,7 @@ export abstract class Part<StateType> {
                 log.error(`Error initializing ${this.name}`, ex)
                 this._initError = ex
                 this._initialized = true // act like it's initialized, the error will be rendered
+                this.dirty()
             })
         }
         this.eachChild(child => {

--- a/src/parts.ts
+++ b/src/parts.ts
@@ -106,6 +106,23 @@ export type MountOptions = {
 }
 
 /**
+ * TuffError is a type of error that has custom behavior for being rendered in a part.
+ */
+export class TuffError extends Error {
+    render(parent: HtmlParentTag) {
+        parent.text(this.toString())
+    }
+}
+
+export function renderErrorInTag(parent: HtmlParentTag, ex: any) {
+    if (ex instanceof TuffError) {
+        ex.render(parent)
+    } else {
+        parent.text(ex.toString())
+    }
+}
+
+/**
  * Base class for all parts.
  */
 export abstract class Part<StateType> {
@@ -782,7 +799,9 @@ export abstract class Part<StateType> {
      * @param ex 
      */
     renderError(parent: PartTag, ex: any) {
-        parent.div(`.tuff-part-error`).text(ex.toString())
+        parent.div(`.tuff-part-error`, container => {
+            renderErrorInTag(container, ex)
+        })
     }
 
     renderInTag(container: HtmlParentTag, ...classes: string[]) {


### PR DESCRIPTION
Current behavior if there's an error while parsing params is to show a blank page. This adds a new error part it will show if there's an error while parsing.

Also adds some functionality so that specific error types can override how they're rendered when shown as a part error.

![CleanShot 2024-09-16 at 15 26 55@2x](https://github.com/user-attachments/assets/c387d31d-9296-474e-95d5-6137242c6016)