### PR TITLE
Ensure that message listeners registered after initialization have a corresponding DOM event listener created

### DIFF
--- a/src/parts.ts
+++ b/src/parts.ts
@@ -538,6 +538,14 @@ export abstract class Part<StateType> {
             options: options,
             callback: handler
         })
+
+        if (this.element) {
+            // If the element has already been rendered, attach the event listener
+            this.addDomListener(this.element, type as EventKey)
+        } else {
+            // Otherwise, make sure that the part is marked to add event listeners after it is rendered
+            this._needsEventListeners = true
+        }
     }
 
     /**
@@ -591,11 +599,16 @@ export abstract class Part<StateType> {
         })
     }
 
+    _attachedListenerTypes = new Set<keyof EventMap>()
+
     /**
      * Attaches an event listener for a particular type of HTML event.
      * Only event types with Tuff listeners will have HTML listeners attached.
      */
     private addDomListener(elem: HTMLElement, type: EventKey) {
+        if (this._attachedListenerTypes.has(type)) return
+        this._attachedListenerTypes.add(type)
+
         const part = this
         let opts: AddEventListenerOptions | undefined = undefined
         if (nonBubblingEvents.includes(type)) {


### PR DESCRIPTION
Normally, you should be registering message listeners during `init`, however there is an edge case (illustrated below) where a part needs to register a message listener passively after the initialization of the root part, which won't work.

```ts
class RootPart extends Part<{}> {
    loaded = false
    async init() {
        doSomethingAsync().then(data => {
            this.assignCollection('children', ChildPart, data)
            this.loaded = true
        })
    }

    render(parent: PartTag) {
        parent.h1().text("Children")
        if (this.loaded) {
            this.renderCollection('children')
        } else {
            parent.div().text("Loading...")
        }
    }
}

const ChildClickedKey = Messages.typedKey<{ childId: string }>()

class ChildPart extends Part<ChildData> {
    async init() {
        // because this is being registered after the initialization of RootPart and it is attach: 'passive',
        // the event listener will never actually get registered on the root part's element.
        this.onClick(ChildClickedKey, m => {
            if (m.data.childId == this.state.id) {
                console.log("A different child was clicked")
            } else {
                console.log(`Child ${this.state.id} clicked`)
            }
        }, { attach: 'passive' })
    }

    render(parent: PartTag) {
        parent.a().text("Click Me!").emitClick(ChildClickedKey, { childId: this.state.id })
    }
}
```