### PR TITLE
assign input name as input id as well

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tuff-core",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tuff-core",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "MIT",
       "dependencies": {
         "path-to-regexp": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "files": [
     "*"
   ],
-  "version": "2.2.3",
+  "version": "2.2.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/Terrier-Tech/tuff"

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -461,6 +461,7 @@ export class FormFields<DataType extends FormPartData> {
     input<Key extends KeyOfType<DataType,any> & string>(parent: PartTag, type: InputType, name: Key, serializerType: FieldConstructor<any, Element>, attrs: InputTagAttrs={}): InputTag {
         attrs.type = type
         attrs.name = this.inputName(name)
+        attrs.id = attrs.name
         if (!this.fields[attrs.name]) {
             this.fields[attrs.name] = new serializerType(name)
         }


### PR DESCRIPTION
Terrier forms' CompoundFieldBuilder renders labels and inputs as siblings rather than in a parent/child structure, so the labels' `for` attribute doesn't do anything. With this change, clicking the label in compound fields like the ones below will check the box:

<img width="1740" height="338" alt="CleanShot 2025-08-22 at 09 56 20@2x" src="https://github.com/user-attachments/assets/aeca3531-c8f8-4c46-8869-dd9133b9052f" />
