### PR TITLE
correctly define colspan and rowspan attrs

### DIFF
--- a/src/demo/table.ts
+++ b/src/demo/table.ts
@@ -22,7 +22,7 @@ export class Table extends Part<{ people?: Person[] }> {
             table.thead().tr(tr => {
                 tr.th().text("ID")
                 tr.th().text("Name")
-                tr.th().text("Birthday")
+                tr.th({colSpan: 2}).text("Birthday")
             })
             this.renderCollection(table, 'rows', 'tbody')
         })
@@ -39,7 +39,7 @@ class TableRow extends Part<Person> {
     render(parent: PartTag) {
         parent.td().text(this.state.id)
         parent.td().text(this.state.name)
-        parent.td().text(this.state.birthday ?? "Birthdayless")
+        parent.td({colSpan: 2}).text(this.state.birthday ?? "Birthdayless")
     }
 
 }

--- a/src/html.ts
+++ b/src/html.ts
@@ -91,7 +91,14 @@ export abstract class HtmlTagBase<AttrsType extends Attrs,ElementType extends HT
 
         // The `for` attribute on a label element is a special case since it's a reserved keyword.
         // In the DOM API it's aliased as `htmlFor`, so we need to unalias it when serializing.
-        if (name == 'htmlFor') name = 'for'
+        // Likewise for `colSpan` and `rowSpan`
+        const serializeNameMap: Record<string, string> = {
+            htmlFor: 'for',
+            colSpan: 'colspan',
+            rowSpan: 'rowspan',
+        }
+
+        if (name in serializeNameMap) name = serializeNameMap[name]
 
         return `${Strings.ropeCase(name)}="${this.escapeAttrValue(value.toString())}"`
     }


### PR DESCRIPTION
Since the default behavior of Tuff tag attributes is to convert camelCase to snake-case, the colSpan and rowSpan attributes currently compile to `col-span` and `row-span` in html. Those properties are incorrect and should be `colspan` and `rowspan`.