### PR TITLE
Feature/tuff scope

### DIFF
--- a/src/demo/demo.scss
+++ b/src/demo/demo.scss
@@ -1,0 +1,6 @@
+// need an scss file to assign a class when rendering collection
+
+.tt-flex {
+  display: flex;
+  gap: 5px;
+}

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -3,6 +3,7 @@ import {Logger} from '../logging'
 import { AddedContactKey, ContactsApp } from "./contacts"
 import * as styles from './styles.css'
 import * as theme from './theme'
+import * as scopedTheme from './scoped-theme'
 import * as counter from './counter'
 import * as contacts from './contacts'
 import * as shapes from './shapes'
@@ -51,6 +52,7 @@ class App extends Part<{}> {
     async init() {
         this.output = this.makePart(OutputPart, { output: undefined })
         this.parts['Theme'] = this.makeStatelessPart(theme.ThemeApp)
+        this.parts['Scoped Theme'] = this.makeStatelessPart(scopedTheme.ScopedThemeApp)
         this.parts['Counter'] = this.makeStatelessPart(counter.CounterApp)
         this.parts['Contacts'] = this.makeStatelessPart(contacts.ContactsApp)
         this.parts['Shapes'] = this.makeStatelessPart(shapes.ShapesApp)

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -2,6 +2,7 @@ import {Part, PartParent, PartTag, StatelessPart} from '../parts'
 import {Logger} from '../logging'
 import { AddedContactKey, ContactsApp } from "./contacts"
 import * as styles from './styles.css'
+import * as theme from './theme'
 import * as counter from './counter'
 import * as contacts from './contacts'
 import * as shapes from './shapes'
@@ -49,6 +50,7 @@ class App extends Part<{}> {
 
     async init() {
         this.output = this.makePart(OutputPart, { output: undefined })
+        this.parts['Theme'] = this.makeStatelessPart(theme.ThemeApp)
         this.parts['Counter'] = this.makeStatelessPart(counter.CounterApp)
         this.parts['Contacts'] = this.makeStatelessPart(contacts.ContactsApp)
         this.parts['Shapes'] = this.makeStatelessPart(shapes.ShapesApp)

--- a/src/demo/scoped-theme.ts
+++ b/src/demo/scoped-theme.ts
@@ -1,0 +1,96 @@
+import {Part, PartTag} from "../parts"
+import * as styles from "./styles.css"
+import * as forms from "../forms"
+import './demo.scss'
+import Messages from "../messages"
+import {createScope} from "../scope"
+
+const Themes = ['light', 'dark']
+type ThemeOptions = typeof Themes[number]
+
+type ThemeScopeType = { style: ThemeOptions }
+const ThemeScope = createScope<ThemeScopeType>()
+
+export class ScopedThemeApp extends Part<{}> {
+    async init() {
+        // Initialize the scope with a default value
+        this.initScope(ThemeScope, { style: 'light' })
+        this.makePart(ScopedThemeDisplay, { theme: 'light' }, 'theme')
+
+        this.listenMessage(ChangeThemeKey, m => {
+            this.assignScope(ThemeScope, { style: m.data.style })
+            // alternative syntax for assigning individual key:
+            // this.assignScopeKey(ThemeScope, 'style', m.data.style)
+        })
+    }
+
+    render(parent: PartTag) {
+        parent.part(this.namedChild('theme')!)
+        // The following text should not update because useScope() was not called for this part
+        parent.div().text(this.getScopeValue(ThemeScope, 'style') == 'light' ? "Light (this should not change)" : "Dark")
+            .css({ padding: "10px" })
+    }
+}
+
+const ChangeThemeKey = Messages.typedKey<{ style: ThemeOptions }>()
+
+class ScopedThemeDisplay extends Part<{ theme: ThemeOptions }> {
+    async init() {
+        // Call useScope() to re-render this part (and its children) whenever the specified scope changes
+        this.useScope(ThemeScope)
+
+        this.assignCollection('text-boxes', ScopedThemeTextBox, [
+            { text: "First" },
+            { text: "Second" },
+            { text: "Third" }
+        ])
+
+        this.makePart(ScopedThemeToggleForm, { theme: this.state.theme }, 'toggle-form')
+    }
+
+    render(parent: PartTag) {
+        parent.div(styles.flexRow, styles.padded, row => {
+            this.renderCollection(row, 'text-boxes')
+                .class('tt-flex')
+            row.part(this.namedChild('toggle-form')!)
+        }).css({ backgroundColor: this.getScopeValue(ThemeScope, 'style') == "light" ? "white" : "darkgray", borderRadius: "5px" })
+    }
+}
+
+class ScopedThemeTextBox extends Part<{ text: string }> {
+    async init() {
+        this.makePart(ThemeText, { text: this.state.text }, 'text')
+    }
+    render(parent: PartTag) {
+        parent.div(box => {
+            box.part(this.namedChild('text')!)
+        }).css({ backgroundColor: this.getScopeValue(ThemeScope, 'style') == "light" ? "#ececec" : "gray", padding: "10px", borderRadius: "5px" })
+    }
+}
+
+class ThemeText extends Part<{ text: string }> {
+    render(parent: PartTag) {
+        parent.div().text(this.state.text).css({color: this.getScopeValue(ThemeScope, 'style') == 'light' ? 'black' : 'white' })
+    }
+}
+
+class ScopedThemeToggleForm extends forms.FormPart<{ theme: ThemeOptions }> {
+    async init() {
+        await super.init()
+        this.onChange(this.formFields.changeKeyForField('theme'), m => {
+            this.emitMessage(ChangeThemeKey, { style: m.data.value })
+        })
+    }
+
+    render(parent: PartTag) {
+        const themeStyle = this.getScopeValue(ThemeScope, 'style')
+        parent.div(styles.flexColumn, col => {
+            Themes.forEach(themeOpt => {
+                col.label(label => {
+                    this.radio(label, "theme", themeOpt)
+                    label.span({text: themeOpt.toUpperCase()}).css({ color: themeStyle == 'light' ? "black" : "white" })
+                })
+            })
+        }).css({ backgroundColor: themeStyle == "light" ? "#ececec" : "gray", padding: "10px", borderRadius: "5px" })
+    }
+}

--- a/src/demo/theme.ts
+++ b/src/demo/theme.ts
@@ -1,0 +1,95 @@
+import {Part, PartTag} from "../parts"
+import * as styles from "./styles.css"
+import * as forms from "../forms"
+import './demo.scss'
+import Messages from "../messages"
+
+const Themes = ['light', 'dark']
+type ThemeOptions = typeof Themes[number]
+
+export class ThemeApp extends Part<{}> {
+    async init() {
+        this.makePart(ThemeDisplay, { theme: 'light' }, 'theme')
+    }
+    render(parent: PartTag) {
+        parent.part(this.namedChild('theme')!)
+    }
+}
+
+const ChangeThemeKey = Messages.typedKey<{ theme: ThemeOptions }>()
+
+export class ThemeDisplay extends Part<{ theme: ThemeOptions }> {
+    async init() {
+        this.assignCollection('text-boxes', ThemeTextBox, [
+            { text: "First", theme: this.state.theme },
+            { text: "Second", theme: this.state.theme },
+            { text: "Third", theme: this.state.theme }
+        ])
+        this.makePart(ThemeToggleForm, { theme: 'light' }, 'toggle-form')
+
+        this.listenMessage(ChangeThemeKey, m => {
+            this.state.theme = m.data.theme
+
+            /**
+             * This is really yucky, but is necessary if we want the child parts to render in relation to the parent state.
+             */
+            const toggleForm = this.namedChild('toggle-form')!
+            toggleForm.state = Object.assign(toggleForm.state, { theme: this.state.theme })
+
+            const textBoxes = this.getCollectionParts('text-boxes')
+            textBoxes.forEach(textBox => textBox.assignState(Object.assign(textBox.state, { theme: this.state.theme })))
+
+            this.dirty()
+        })
+    }
+    render(parent: PartTag) {
+        parent.div(styles.flexRow, styles.padded, row => {
+            this.renderCollection(row, 'text-boxes')
+                .class('tt-flex')
+            row.part(this.namedChild('toggle-form')!)
+        }).css({ backgroundColor: this.state.theme == "light" ? "white" : "darkgray", borderRadius: "5px" })
+    }
+}
+
+export class ThemeTextBox extends Part<{ text: string, theme: ThemeOptions }> {
+    async init() {
+        this.makePart(ThemeText, { text: this.state.text, theme: this.state.theme }, 'text')
+    }
+
+    assignState(state: { text: string, theme: ThemeOptions }) {
+        this.namedChild('text')!.state = state
+        return super.assignState(state)
+    }
+    render(parent: PartTag) {
+        parent.div(box => {
+            box.part(this.namedChild('text')!)
+        }).css({ backgroundColor: this.state.theme == "light" ? "#ececec" : "gray", padding: "10px", borderRadius: "5px" })
+    }
+}
+
+export class ThemeText extends Part<{ text: string, theme: ThemeOptions }> {
+    render(parent: PartTag) {
+        parent.div().text(this.state.text).css({color: this.state.theme == 'light' ? 'black' : 'white' })
+    }
+}
+
+export class ThemeToggleForm extends forms.FormPart<{ theme: ThemeOptions }> {
+    async init() {
+        await super.init()
+        this.onChange(this.formFields.changeKeyForField('theme'), m => {
+            console.log("Theme changed", m.data)
+            this.emitMessage(ChangeThemeKey, { theme: m.data.value })
+        })
+    }
+
+    render(parent: PartTag) {
+        parent.div(styles.flexColumn, col => {
+            Themes.forEach(themeOpt => {
+                col.label(label => {
+                    this.radio(label, "theme", themeOpt)
+                    label.span({text: themeOpt.toUpperCase()}).css({ color: this.state.theme == 'light' ? "black" : "white" })
+                })
+            })
+        }).css({ backgroundColor: this.state.theme == "light" ? "#ececec" : "gray", padding: "10px", borderRadius: "5px" })
+    }
+}

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,23 @@
+import Messages from "./messages"
+
+/**
+ * Helper methods for creating and using scopes
+ */
+export type ScopeToken<T> = symbol & { _type?: T }
+type ScopeUpdate<T extends object> = {
+    token: ScopeToken<T>,
+    key: keyof T,
+    value: T[keyof T]
+};
+
+export function typedScopeUpdate<T extends object>() {
+    return Messages.typedKey<ScopeUpdate<T>>()
+}
+
+export function createScope<T>(): ScopeToken<T> {
+    return Symbol() as ScopeToken<T>
+}
+
+export const Scopes = new Map<ScopeToken<any>, unknown>()
+
+export const ScopeMessageKeys = new Map<ScopeToken<any>, any>()


### PR DESCRIPTION
In working on the proposal revamp, I've come up against this recurring problem. As changes are made to the contract and its elements, those changes should be shared among the tree of parts. This can be clunky for sibling or cousin parts, because even if they are re-rendered along with their parents, their state does not automatically update automatically along with the parent's state. See the below workaround `ProposalDocumentStep`: 
<img width="1142" height="608" alt="CleanShot 2026-01-05 at 12 32 45@2x" src="https://github.com/user-attachments/assets/e5c57dde-1b74-410c-b5e0-dc5408ce8667" />

This is a very near repeat of the child part creation in the same part's initialization:
<img width="936" height="598" alt="CleanShot 2026-01-05 at 12 31 40@2x" src="https://github.com/user-attachments/assets/bc7ddd89-9095-4d78-8739-288f691145a0" />

Yuck!

The solution here is a new and relatively simple shared state management tool called `Scope`. It is a rough imitation of react's [context](https://react.dev/learn/passing-data-deeply-with-context), which came in handy when working on clypboard-expo. Not only does this seriously mitigate the state management headache, it also reduces the need for 'prop drilling:' passing down the same data many layers deep through a tree of parts so that they all have access to it. This difference can be seen in the comparison between the two examples in this PR. 

The main downside of using scopes is that including attachScope() limits parts' reusability and encapsulation, as they are now tied down to living in a tree with that specific scope. But in something like the proposal revamp, this isn't really an issue as those parts won't have a life outside of the proposal workflow.