### PR TITLE
state context class

### DIFF
--- a/src/state-context.ts
+++ b/src/state-context.ts
@@ -1,0 +1,114 @@
+import Messages from "./messages"
+import {Part, PartConstructor} from "./parts"
+
+type ArrayKeys<T> = {
+    [P in keyof T]: T[P] extends readonly unknown[] | undefined ? P : never
+}[keyof T]
+type ElementOf<T> = T extends readonly (infer U)[] ? U : never
+
+export class StateContext<T extends object> {
+    part: Part<unknown>
+    data: T
+    changeMessageKey = Messages.typedKey<{ key: keyof T | null }>()
+
+    constructor(part: Part<unknown>, initialData: T) {
+        this.part = part
+        this.data = initialData
+    }
+
+    /**
+     * Bind a part to a context, forcing it to re-render whenever any value
+     * on the context changes
+     * @param part The part to mark as dirty on context change
+     * @param beforeRender optional method to occur before rerender but after context change
+     */
+    bind(part: Part<unknown>, beforeRender?: () => void) {
+        part.listenMessage(this.changeMessageKey, _ => {
+            beforeRender?.()
+            part.dirty()
+        }, { attach: 'passive' })
+    }
+
+    /**
+     * Bind a part to a single key on a context, triggering a re-render when that key changes
+     * @param part The part to mark as dirty
+     * @param key The context key
+     */
+    selectiveBind<K extends keyof T>(part: Part<unknown>, key: K) {
+        part.listenMessage(
+            this.changeMessageKey,
+            m => {
+                // if key is null, then full state was assigned
+                if (m.data.key === key || m.data.key === null) {
+                    part.dirty()
+                }
+            },
+            { attach: 'passive' }
+        )
+    }
+
+    /**
+     * Bind a context key to a tuff collection
+     * @param part The parent part. Will be rerendered on context key change.
+     * @param contextKey
+     * @param collectionName
+     * @param collectionPartKey
+     * @param partType
+     */
+    bindKeyToCollection<
+        K extends ArrayKeys<T>,
+        Item extends ElementOf<NonNullable<T[K]>>,
+        CollectionKey extends string,
+        State extends Record<CollectionKey, Item>
+    >(
+        part: Part<unknown>,
+        contextKey: K,
+        collectionName: string,
+        collectionPartKey: CollectionKey,
+        partType: PartConstructor<Part<State>, State>
+    ) {
+        part.listenMessage(
+            this.changeMessageKey,
+            m => {
+                if (m.data.key === contextKey || m.data.key === null) {
+                    const existingCollectionStates = (part.getCollectionParts(collectionName) as Part<State>[])
+                        .map(part => part.state)
+
+                    const items = this.data[contextKey] as Item[]
+
+                    const newStates: State[] = items.map((item, index) => {
+                        const existingState = existingCollectionStates[index]
+                        return {
+                            ...(existingState ?? {}),
+                            [collectionPartKey]: item,
+                        } as State
+                    })
+
+                    part.assignCollection(collectionName, partType, newStates)
+                    part.dirty()
+                }
+            }, { attach: 'passive' }
+        )
+    }
+
+    /**
+     * Assign the context data to a value. Will trigger rerenders on all
+     * parts bound to the context.
+     * @param data
+     */
+    assignState(data: T) {
+        this.data = data
+        this.part.emitMessage(this.changeMessageKey, { key: null })
+    }
+
+    /**
+     * Assign a single key in the context to a value. Will trigger rerenders
+     * on parts bound either to the full context or to the specified key.
+     * @param key
+     * @param value
+     */
+    assignStateValue<K extends keyof T>(key: keyof T, value: T[K]) {
+        Object.assign(this.data, {[key]: value})
+        this.part.emitMessage(this.changeMessageKey, { key: key })
+    }
+}

--- a/src/state-context.ts
+++ b/src/state-context.ts
@@ -1,5 +1,5 @@
-import Messages from "./messages"
 import {Part, PartConstructor} from "./parts"
+import Messages from "./messages"
 
 type ArrayKeys<T> = {
     [P in keyof T]: T[P] extends readonly unknown[] | undefined ? P : never
@@ -34,12 +34,13 @@ export class StateContext<T extends object> {
      * @param part The part to mark as dirty
      * @param key The context key
      */
-    selectiveBind<K extends keyof T>(part: Part<unknown>, key: K) {
+    selectiveBind<K extends keyof T>(part: Part<unknown>, key: K, beforeRender?: () => void) {
         part.listenMessage(
             this.changeMessageKey,
             m => {
-                // if key is null, then full state was assigned
+                // if the key is null, then the full state was assigned
                 if (m.data.key === key || m.data.key === null) {
+                    beforeRender?.()
                     part.dirty()
                 }
             },
@@ -49,43 +50,41 @@ export class StateContext<T extends object> {
 
     /**
      * Bind a context key to a tuff collection
-     * @param part The parent part. Will be rerendered on context key change.
      * @param contextKey
+     * @param parentPart The parent part. Will be rerendered on context key change.
      * @param collectionName
-     * @param collectionPartKey
-     * @param partType
+     * @param collectionPart
+     * @param stateBuilder
      */
     bindKeyToCollection<
         K extends ArrayKeys<T>,
         Item extends ElementOf<NonNullable<T[K]>>,
-        CollectionKey extends string,
-        State extends Record<CollectionKey, Item>
+        ElementState extends object,
     >(
-        part: Part<unknown>,
         contextKey: K,
+        parentPart: Part<unknown>,
         collectionName: string,
-        collectionPartKey: CollectionKey,
-        partType: PartConstructor<Part<State>, State>
+        collectionPart: PartConstructor<Part<ElementState>, ElementState>,
+        stateBuilder: (item: Item, context: StateContext<T>) => ElementState
     ) {
-        part.listenMessage(
+        const items = this.data[contextKey] as Item[]
+        const initialStates = items?.map(item => stateBuilder(item, this))
+        if (initialStates?.length) {
+            parentPart.assignCollection(collectionName, collectionPart, initialStates)
+        }
+
+        parentPart.listenMessage(
             this.changeMessageKey,
             m => {
                 if (m.data.key === contextKey || m.data.key === null) {
-                    const existingCollectionStates = (part.getCollectionParts(collectionName) as Part<State>[])
-                        .map(part => part.state)
-
                     const items = this.data[contextKey] as Item[]
 
-                    const newStates: State[] = items.map((item, index) => {
-                        const existingState = existingCollectionStates[index]
-                        return {
-                            ...(existingState ?? {}),
-                            [collectionPartKey]: item,
-                        } as State
+                    const newStates: ElementState[] = items.map(item => {
+                        return stateBuilder(item, this)
                     })
 
-                    part.assignCollection(collectionName, partType, newStates)
-                    part.dirty()
+                    parentPart.assignCollection(collectionName, collectionPart, newStates)
+                    parentPart.dirty()
                 }
             }, { attach: 'passive' }
         )


### PR DESCRIPTION
improvement on https://github.com/Terrier-Tech/tuff/pull/21. I'm wrapping up proposal revamp and don't expect to find many other ways that this state context should be improved, so I think it's time to get it into master.

The most notable addition I've made since the conversation in the other pr is the `bindKeyToCollection` method, which is useful when we want a tuff collection to stay linked to a key in a state context.